### PR TITLE
searchTerm containing Capital Letter returns no story

### DIFF
--- a/src/components/Dashboard.js
+++ b/src/components/Dashboard.js
@@ -13,7 +13,7 @@ export default function Dashboard({searchResults, setSearchResults, searchTerm})
 
     useEffect(() => {
         const results = appData&&appData.filter(story =>
-            story.item.headline[0].toLowerCase().includes(searchTerm)
+            story.item.headline[0].toLowerCase().includes(searchTerm.toLowerCase())
         );
         setSearchResults(results);
     }, [searchTerm]);


### PR DESCRIPTION
If you search a story on the TopBar with a Capital letter it fails to return the story